### PR TITLE
Reference hb fonts in raqm_itemize

### DIFF
--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1156,7 +1156,7 @@ _raqm_itemize (raqm_t *rq)
     {
       run->pos = runs[i].pos + runs[i].len - 1;
       run->script = rq->text_info[run->pos].script;
-      run->font = rq->text_info[run->pos].font;
+      run->font = hb_font_reference(rq->text_info[run->pos].font);
       for (int j = runs[i].len - 1; j >= 0; j--)
       {
         _raqm_text_info info = rq->text_info[runs[i].pos + j];
@@ -1172,7 +1172,7 @@ _raqm_itemize (raqm_t *rq)
           newrun->len = 1;
           newrun->direction = _raqm_hb_dir (rq, runs[i].level);
           newrun->script = info.script;
-          newrun->font = info.font;
+          newrun->font = hb_font_reference(info.font);
           run->next = newrun;
           run = newrun;
         }
@@ -1187,7 +1187,7 @@ _raqm_itemize (raqm_t *rq)
     {
       run->pos = runs[i].pos;
       run->script = rq->text_info[run->pos].script;
-      run->font = rq->text_info[run->pos].font;
+      run->font = hb_font_reference(rq->text_info[run->pos].font);
       for (size_t j = 0; j < runs[i].len; j++)
       {
         _raqm_text_info info = rq->text_info[runs[i].pos + j];
@@ -1203,7 +1203,7 @@ _raqm_itemize (raqm_t *rq)
           newrun->len = 1;
           newrun->direction = _raqm_hb_dir (rq, runs[i].level);
           newrun->script = info.script;
-          newrun->font = info.font;
+          newrun->font = hb_font_reference(info.font);
           run->next = newrun;
           run = newrun;
         }


### PR DESCRIPTION
> I'm trying to compile this to webassembly based on the example that used to be available on https://github.com/harfbuzz/harfbuzzjs. While it works it does frequently run into "memory access out of bounds" error after a while.
> 
> Submitted PR fixes the issue however honestly I'm not 100% sure the change is correct.
> When the freetype dependency was removed and each raqm run is directly assigned a reference to hb_font the reference count on hb_font should also be increased, otherwise at the end of layout process the font is destroyed in _raqm_free_text_info and _raqm_free_runs even though it can still be referenced elsewhere as we never increase the reference count.
